### PR TITLE
Fix: Fehlenden NULL Check in ObjectDumper.AlreadyTouched Methode erga…

### DIFF
--- a/dff.Extensions/HelperClasses/ObjectDumper.cs
+++ b/dff.Extensions/HelperClasses/ObjectDumper.cs
@@ -114,6 +114,8 @@ namespace dff.Extensions.HelperClasses
 
         private bool AlreadyTouched(object value)
         {
+            if (value == null) return false;
+            
             var hash = value.GetHashCode();
             for (var i = 0; i < _hashListOfFoundElements.Count; i++)
             {


### PR DESCRIPTION
…enzt

Die Dump-Methode warf eine NullReferenceException, wenn in einem IEnumerable Einträge mit dem Wert NULL verarbeitet wurden.